### PR TITLE
商品詳細表示機能実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@
 
 ## items テーブル
 
-| Column        | Type       | Options                        |
-| ------------- | ---------- | ------------------------------ |
-| title         | string     | null: false                    |
-| text          | text       | null: false                    |
-| category      | integer    | null: false                    |
-| condition     | integer    | null: false                    |
-| delivery_fee  | integer    | null: false                    |
-| delivery_area | integer    | null: false                    |
-| shipping_day  | integer    | null: false                    |
-| price         | integer    | null: false                    |
-| user          | references | null: false, foreign_key: true |
+| Column           | Type       | Options                        |
+| -------------    | ---------- | ------------------------------ |
+| title            | string     | null: false                    |
+| text             | text       | null: false                    |
+| category_id      | integer    | null: false                    |
+| condition-id     | integer    | null: false                    |
+| delivery_fee_id  | integer    | null: false                    |
+| delivery_area_id | integer    | null: false                    |
+| shipping_day_id  | integer    | null: false                    |
+| price            | integer    | null: false                    |
+| user             | references | null: false, foreign_key: true |
 
 
 ### items-Association

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index,:show]
 
   def index
     @items = Item.all.order("created_at DESC")
@@ -18,10 +18,14 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:image, :title, :text, :category, :condition, :delivery_fee, :delivery_area, :shipping_day, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :title, :text, :category_id, :condition_id, :delivery_fee_id, :delivery_area_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index,:show]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,4 @@
-class CategoryGenre < ActiveHash::Base
+class Category < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: 'レディース' },

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,4 +1,4 @@
-class ConditionGenre < ActiveHash::Base
+class Condition < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '新品、未使用' },

--- a/app/models/delivery_area.rb
+++ b/app/models/delivery_area.rb
@@ -1,4 +1,4 @@
-class DeliveryAreaGenre < ActiveHash::Base
+class DeliveryArea < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '北海道' },

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,4 +1,4 @@
-class DeliveryFeeGenre < ActiveHash::Base
+class DeliveryFee < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い(購入者負担)' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,25 +1,25 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to_active_hash :category_genre
-  belongs_to_active_hash :condition_genre
-  belongs_to_active_hash :delivery_fee_genre
-  belongs_to_active_hash :delivery_area_genre
-  belongs_to_active_hash :shipping_day_genre
+  belongs_to_active_hash :category
+  belongs_to_active_hash :condition
+  belongs_to_active_hash :delivery_fee
+  belongs_to_active_hash :delivery_area
+  belongs_to_active_hash :shipping_day
 
-  validates :title,         presence: true, length: { maximum: 40 }
-  validates :text,          presence: true, length: { maximum: 1000 }
-  validates :category,      presence: true
-  validates :condition,     presence: true
-  validates :delivery_fee,  presence: true
-  validates :delivery_area, presence: true
-  validates :shipping_day,  presence: true
-  validates :price,         presence: true, numericality: { with: /\A[0-9]+\z/, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+  validates :title,            presence: true, length: { maximum: 40 }
+  validates :text,             presence: true, length: { maximum: 1000 }
+  validates :category_id,      presence: true
+  validates :condition_id,     presence: true
+  validates :delivery_fee_id,  presence: true
+  validates :delivery_area_id, presence: true
+  validates :shipping_day_id,  presence: true
+  validates :price,            presence: true, numericality: { with: /\A[0-9]+\z/, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 
-  validates :category,      numericality: { other_than: 1 }
-  validates :condition,     numericality: { other_than: 1 }
-  validates :delivery_fee,  numericality: { other_than: 1 }
-  validates :delivery_area, numericality: { other_than: 1 }
-  validates :shipping_day,  numericality: { other_than: 1 }
+  validates :category_id,      numericality: { other_than: 1 }
+  validates :condition_id,     numericality: { other_than: 1 }
+  validates :delivery_fee_id,  numericality: { other_than: 1 }
+  validates :delivery_area_id, numericality: { other_than: 1 }
+  validates :shipping_day_id,  numericality: { other_than: 1 }
 
   validates :image,         presence: true
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -21,7 +21,7 @@ class Item < ApplicationRecord
   validates :delivery_area_id, numericality: { other_than: 1 }
   validates :shipping_day_id,  numericality: { other_than: 1 }
 
-  validates :image,         presence: true
+  validates :image, presence: true
 
   belongs_to :user
   has_one_attached :image

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -1,4 +1,4 @@
-class ShippingDayGenre < ActiveHash::Base
+class ShippingDay < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '1〜2日で発送' },

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item|%>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image , class: "item-img" %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, CategoryGenre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, CategoryGenre.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:condition, ConditionGenre.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, ConditionGenre.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_fee, DeliveryFeeGenre.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFeeGenre.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_area, DeliveryAreaGenre.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:delivery_area_id, DeliveryAreaGenre.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_day, ShippingDayGenre.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDayGenre.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,19 +4,19 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.title %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+  <%# <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,13 +24,15 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <%# 商品が売れていない場合はこちらを表示しましょう %> 
+    <% unless user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
@@ -43,27 +45,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.delivery_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create, :index]
+  resources :items, only: [:new, :create, :index, :show]
 end

--- a/db/migrate/20200914020615_create_items.rb
+++ b/db/migrate/20200914020615_create_items.rb
@@ -1,15 +1,15 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.string  :title,          null: false
-      t.text    :text,           null: false
-      t.integer :category,       null: false
-      t.integer :condition,      null: false
-      t.integer :delivery_fee,   null: false
-      t.integer :delivery_area,  null: false
-      t.integer :shipping_day,   null: false
-      t.integer :price,          null: false
-      t.references :user,        foreign_key: true
+      t.string  :title,             null: false
+      t.text    :text,              null: false
+      t.integer :category_id,       null: false
+      t.integer :condition_id,      null: false
+      t.integer :delivery_fee_id,   null: false
+      t.integer :delivery_area_id,  null: false
+      t.integer :shipping_day_id,   null: false
+      t.integer :price,             null: false
+      t.references :user,           foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,11 +36,11 @@ ActiveRecord::Schema.define(version: 2020_09_14_034616) do
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "text", null: false
-    t.integer "category", null: false
-    t.integer "condition", null: false
-    t.integer "delivery_fee", null: false
-    t.integer "delivery_area", null: false
-    t.integer "shipping_day", null: false
+    t.integer "category_id", null: false
+    t.integer "condition_id", null: false
+    t.integer "delivery_fee_id", null: false
+    t.integer "delivery_area_id", null: false
+    t.integer "shipping_day_id", null: false
     t.integer "price", null: false
     t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :item do
     title         { Faker::Name.initials(number: 40) }
     text          { Faker::Name.initials(number: 50) }
-    category      { '2' }
-    condition     { '2' }
-    delivery_fee  { '2' }
-    delivery_area { '2' }
-    shipping_day  { '2' }
+    category_id      { '2' }
+    condition_id     { '2' }
+    delivery_fee_id  { '2' }
+    delivery_area_id { '2' }
+    shipping_day_id  { '2' }
     price         { '300' }
     association   :user
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -27,29 +27,29 @@ describe Item do
         expect(@item.errors.full_messages).to include("Text can't be blank")
       end
       it 'カテゴリーが選択されていないと登録できない' do
-        @item.category = 1
+        @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it '商品の状態が選択されていないと登録できない' do
-        @item.category = 1
+        @item.condition_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
       it '配送料の負担について選択されていないと登録できない' do
-        @item.category = 1
+        @item.delivery_fee_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('Delivery fee must be other than 1')
       end
       it '発送元の地域が選択されていないと登録できない' do
-        @item.category = 1
+        @item.delivery_area_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('Delivery area must be other than 1')
       end
       it '発送までの日数について選択されていないと登録できない' do
-        @item.category = 1
+        @item.shipping_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Category must be other than 1')
+        expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
       end
       it '価格が入力されていないと登録できない' do
         @item.price = nil


### PR DESCRIPTION
#what
商品詳細表示機能追加
#what
出品した商品の詳細を確認する為

※出品者、他ログインユーザー、未登録者で詳細に表示が分岐する機能は
下記キャプチャGIFのログインよりご確認ください。
出品者ログイン時:https://gyazo.com/1dc9e77d2370319b391d0bd5034f08a0
他ログインユーザー時:https://gyazo.com/91399a12aeb2b08b576fc53d5f250fb0
未登録ユーザー時:https://gyazo.com/8f8d3f6a54f7eaf9a0b9d734b214e792

※詳細表示でカテゴリー選択項目がIDの数字で表示される問題があった為、
itemテーブルのカラムを修正しました。例:condition→condition_id
マイグレーションやモデルのバリデーション、単体テストコードなど修正がgit hubの修正履歴が多くなり見辛くご迷惑をお掛けしますが、宜しくお願いいたします。